### PR TITLE
Fix bugs with cleanup

### DIFF
--- a/pkg/mv/share/share.go
+++ b/pkg/mv/share/share.go
@@ -120,7 +120,7 @@ func awsShareLogs(ctx context.Context, region, id string, conf Config) (string, 
 		}
 		mv.QueueCleanup(func() {
 			logging.Info("Deleting temporary AWS key pair")
-			err := awsSvc.RemoveKeyPair(ctx, randomName)
+			err := awsSvc.RemoveKeyPair(context.Background(), randomName)
 			if err != nil {
 				logging.Errorf("Failed to clean up key pair in AWS: %s", randomName)
 				logging.Debugf("Error when deleting key pair in AWS: %s", err)
@@ -177,7 +177,7 @@ func awsShareLogs(ctx context.Context, region, id string, conf Config) (string, 
 	}
 	mv.QueueCleanup(func() {
 		logging.Infof("Terminating temporary instance %s", instance.ID())
-		err := awsSvc.TerminateInstance(ctx, instance.ID())
+		err := awsSvc.TerminateInstance(context.Background(), instance.ID())
 		if err != nil {
 			logging.Errorf("Failed to cleanup instance: %s", instance.ID())
 			logging.Debugf("Got error when terminating instance: %s", err)

--- a/pkg/mv/wrap/image.go
+++ b/pkg/mv/wrap/image.go
@@ -41,9 +41,10 @@ func awsWrapImage(ctx context.Context, awsSvc aws.Service, region, id string, co
 	mv.QueueCleanup(func() {
 		// Finally clean up temporary instance
 		logging.Info("Cleaning up temporary instance")
-		err = awsSvc.TerminateInstance(ctx, inst.ID())
+		err = awsSvc.TerminateInstance(context.Background(), inst.ID())
 		if err != nil {
 			logging.Warningf("Failed to cleanup temporary instance %s", inst.ID())
+			logging.Debugf("Error when cleaning up instance: %s", err)
 		}
 		logging.Infof("Instance %s terminated", inst.ID())
 	}, false)

--- a/pkg/mv/wrap/instance.go
+++ b/pkg/mv/wrap/instance.go
@@ -45,7 +45,11 @@ func awsWrapInstance(ctx context.Context, awsSvc aws.Service, region, id string,
 
 	// Stop the instance so that devices can be modified
 	logging.Info("Stopping the instance")
-	awsSvc.StopInstance(ctx, id)
+	err = awsSvc.StopInstance(ctx, id)
+	if err != nil {
+		// Could not stop the instance
+		return "", err
+	}
 	logging.Info("Instance stopped")
 
 	// Set userdata on instance based on parameters


### PR DESCRIPTION
Fixes one bug where the error was not checked on instance termination.
Also makes sure that a new context is created for cleanup functions. If
the previous context is passed, when the user interupts the context will
be cancelled, thus always failing the cleanup steps.