### PR TITLE
Fixed issue with MV version retrieval & some typos

### DIFF
--- a/pkg/mv/aws.go
+++ b/pkg/mv/aws.go
@@ -123,17 +123,17 @@ func determineLatest(ctx context.Context, client *s3.S3, allVersions []string) (
 func getObjectBody(ctx context.Context, client *s3.S3, key string) (map[string]string, error) {
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(prodBucketName),
-		Key:    aws.String(latestKey),
+		Key:    aws.String(key),
 	}
-	latest, err := client.GetObjectWithContext(ctx, input)
+	amis, err := client.GetObjectWithContext(ctx, input)
 	if err != nil {
 		return nil, err
 	}
-	decoder := json.NewDecoder(latest.Body)
-	latestMap := make(map[string]string)
-	err = decoder.Decode(&latestMap)
+	decoder := json.NewDecoder(amis.Body)
+	amisMap := make(map[string]string)
+	err = decoder.Decode(&amisMap)
 	if err != nil {
 		return nil, err
 	}
-	return latestMap, nil
+	return amisMap, nil
 }

--- a/pkg/mv/wrap/instance.go
+++ b/pkg/mv/wrap/instance.go
@@ -40,8 +40,8 @@ func awsWrapInstance(ctx context.Context, awsSvc aws.Service, region, id string,
 	if err != nil {
 		return "", err
 	}
-	mvVolumeSIze := mvSnapshot.SizeGB()
-	logging.Debugf("MV snapshot is %d GiB", mvVolumeSIze)
+	mvVolumeSize := mvSnapshot.SizeGB()
+	logging.Debugf("MV snapshot is %d GiB", mvVolumeSize)
 
 	// Stop the instance so that devices can be modified
 	logging.Info("Stopping the instance")


### PR DESCRIPTION
Fixed an issue where the latest MV version was always pulled in, due to `latestKey` always being used when searching for a folder in the prod bucket, instead of searching for the `key` passed to the function.

Also fixed a typo (`mvVolumeSIze ` --> `mvVolumeSize`) as well as renamed some variables so that they make more sense. (`latestMap` --> `amisMap`)

Tested and this:
* Still pulls the latest MV versions by default
* Can pull a custom MV version using the `--metavisor-version` flag
* Outputs a helpful error if a non-existing MV version is specified:
```
metavisor --verbose aws wrap-ami --region us-west-2 --token="$LAUNCH_TOKEN" --metavisor-version=metavisor-2-162-74-g3afe96bea ami-79873901
INFO:  Creating wrapped image based on ami-79873901...
INFO:  Launching temporary wrapper instance
DEBUG: Launching instance without key pair
INFO:  Waiting for instance to become ready...
INFO:  Instance is ready
INFO:  Wrapping the temporary instance with Metavisor
INFO:  Using Metavisor version metavisor-2-162-74-g3afe96bea
ERROR: Could not find AMIs for the specified MV version
ERROR: Failed to wrap the temporary instance
DEBUG: Running cleanup function
INFO:  Cleaning up temporary instance
INFO:  Instance i-0e65d5eeb01ca5cd1 terminated
INFO:  Cleanup completed
FATAL: NoSuchKey: The specified key does not exist.
	status code: 404, request id: 85298F0CF18EA339, host id: rEmpjREm3S5RlQcwxdgvLocWk3DuEGC3DhG2HCWpNUttunQUh9beSPjHyptnBA9WngbqIHkvasg=
Logs are available at:
/var/folders/y9/dysjpgps7k18qq2fkl9tqs440000gn/T/metavisor-cli-log611036657
```
(`metavisor-2-162-74-g3afe96bea` is not a real MV)