### PR TITLE
Add unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 
 script:
   # First run tests
-  - go test -v -race ./...
+  - make test
   # Then attempt to build for all platforms
   - make build-all
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ endif
 
 all: build
 
+test: deps
+	go test -race ./...
+
 deps:
 	dep ensure
 

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,0 +1,55 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"testing"
+)
+
+func TestLoggingBasic(t *testing.T) {
+	var b bytes.Buffer
+	termLogger = log.New(&b, "", 0)
+	LogLevel = LevelInfo
+	Info("Hello World!")
+	if s := b.String(); s == fmt.Sprintf(templateInfo, "Hello World!") {
+		t.Errorf("should not have prefix when level = INFO and writing to terminal\nGot: %s", s)
+	}
+	LogLevel = LevelDebug
+	b.Reset()
+	Info("Hello World!")
+	if s := b.String(); s != fmt.Sprintf(templateInfo+"\n", "Hello World!") {
+		t.Errorf("should have prefix when level = DEBUG and writing to terminal\nGot: %s", s)
+	}
+}
+
+func TestLogAll(t *testing.T) {
+	var b bytes.Buffer
+	termLogger = log.New(&b, "", 0)
+	LogLevel = LevelInfo
+	expected := `Hello info
+WARN:  Hello warn
+ERROR: Hello error
+`
+	Info("Hello info")
+	Debug("Hello debug") // Should not show
+	Warning("Hello warn")
+	Error("Hello error")
+	if s := b.String(); s != expected {
+		t.Errorf("Didn't get expected logs.\nGot:\n%s\nExpected:\n%s", s, expected)
+	}
+}
+
+func TestLogOutvsErr(t *testing.T) {
+	var stdErr, stdOut bytes.Buffer
+	termLogger = log.New(&stdErr, "", 0)
+	outLogger = log.New(&stdOut, "", 0)
+
+	Info("Something")
+	Warning("Something else")
+	Debug("More stuff")
+	Output("This is the output")
+	if out := stdOut.String(); out != "This is the output\n" {
+		t.Error("only the output should be logged to stdOut")
+	}
+}

--- a/pkg/mv/list_test.go
+++ b/pkg/mv/list_test.go
@@ -1,0 +1,54 @@
+package mv
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestListFormatSimple(t *testing.T) {
+	latest := "latest-version"
+	versions := MetavisorVersions{
+		Latest: latest,
+		Versions: []string{
+			latest,
+			"other-version",
+			"some-other-version",
+		},
+	}
+	simpleFormat, err := FormatMetavisors(versions, false)
+	if err != nil {
+		t.Fatalf("Got error when formatting without JSON:\n%s", err)
+	}
+
+	expected := `latest-version (latest)
+other-version
+some-other-version`
+	if simpleFormat != expected {
+		t.Fatalf("Got unexpected output:\n%s", simpleFormat)
+	}
+}
+
+func TestListFormatJSON(t *testing.T) {
+	latest := "latest-version"
+	versions := MetavisorVersions{
+		Latest: latest,
+		Versions: []string{
+			latest,
+			"other-version",
+			"some-other-version",
+		},
+	}
+	jsonFormat, err := FormatMetavisors(versions, true)
+	if err != nil {
+		t.Fatalf("Got error when formatting with JSON:\n%s", err)
+	}
+
+	r := MetavisorVersions{}
+	err = json.Unmarshal([]byte(jsonFormat), &r)
+	if err != nil {
+		t.Fatalf("Got error when unmarshalling: %s", err)
+	}
+	if r.Latest != latest {
+		t.Errorf("Latest is not corrects %s != %s", r.Latest, latest)
+	}
+}

--- a/pkg/mv/mv_test.go
+++ b/pkg/mv/mv_test.go
@@ -1,0 +1,29 @@
+package mv
+
+import "testing"
+
+func TestCleanup(t *testing.T) {
+	didRun := false
+	f := func() {
+		didRun = true
+	}
+	queuedCleanups = nil
+	QueueCleanup(f, true)
+	Cleanup(true)
+	if didRun {
+		t.Error("Cleanup should only have run if failure happened")
+	}
+	Cleanup(false)
+	if !didRun {
+		t.Error("Cleanup never happened")
+	}
+	didAlwaysRun := false
+	fAlways := func() {
+		didAlwaysRun = true
+	}
+	QueueCleanup(fAlways, false)
+	Cleanup(true)
+	if !didAlwaysRun {
+		t.Error("Cleanup function never ran")
+	}
+}

--- a/pkg/mv/version_test.go
+++ b/pkg/mv/version_test.go
@@ -1,0 +1,88 @@
+package mv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGetCLIVersion(t *testing.T) {
+	i, _ := GetInfo(context.Background())
+	if i.CLIVersion != CLIVersion {
+		t.Errorf("CLI version should always be returned. Got: %s, Expected: %s", i.CLIVersion, CLIVersion)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		foo, err := GetInfo(ctx)
+		if fmt.Sprint(err) != "context canceled" {
+			t.Errorf("Expected context to be cancelled, got: %s", err)
+		}
+		if foo.CLIVersion != CLIVersion {
+			t.Errorf("Didn't get correct CLI version after cancel. Got: %s, Expected: %s", foo.CLIVersion, CLIVersion)
+		}
+		wg.Done()
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	wg.Wait()
+}
+
+func TestVersionFormat(t *testing.T) {
+	info := Info{
+		CLIVersion: "the-cli-version",
+		MVVersion:  "metavisor-1-2-3-abc",
+		Success:    true,
+	}
+
+	simpleFormat, err := FormatInfo(&info, false)
+	if err != nil {
+		t.Errorf("Got error when formatting without JSON: %s", err)
+	}
+	expected := `CLI Version:	the-cli-version
+MV Version:	metavisor-1-2-3-abc`
+	if simpleFormat != expected {
+		t.Errorf("bad format, Got:\n%s\nExpected:\n%s", simpleFormat, expected)
+	}
+
+	info.MVVersion = ""
+
+	simpleFormat, err = FormatInfo(&info, false)
+	if err != nil {
+		t.Errorf("Got error when formatting without JSON: %s", err)
+	}
+	expected = `CLI Version:	the-cli-version
+MV Version:	<couldn't fetch>`
+	if simpleFormat != expected {
+		t.Errorf("bad format, Got:\n%s\nExpected:\n%s", simpleFormat, expected)
+	}
+}
+
+func TestVersionFormatJSON(t *testing.T) {
+	info := Info{
+		CLIVersion: "the-cli-version",
+		MVVersion:  "metavisor-1-2-3-abc",
+		Success:    true,
+	}
+
+	jsonF, err := FormatInfo(&info, true)
+	if err != nil {
+		if err != nil {
+			t.Errorf("Got error when formatting with JSON: %s", err)
+		}
+	}
+
+	res := Info{}
+	err = json.Unmarshal([]byte(jsonF), &res)
+	if err != nil {
+		t.Fatalf("Could not unmarshal the JSON produced")
+	}
+	if res.CLIVersion != "the-cli-version" {
+		t.Errorf("CLI version wrong after unmarshal: %s", res.CLIVersion)
+	}
+}

--- a/pkg/userdata/userdata_test.go
+++ b/pkg/userdata/userdata_test.go
@@ -1,0 +1,41 @@
+package userdata
+
+import "testing"
+
+func TestEmptyContainer(t *testing.T) {
+	c := New()
+	expected := `From nobody Tue Dec  3 19:00:57 2013
+Content-Type: multipart/mixed; boundary="--===============HI-20131203==--"
+MIME-Version: 1.0
+
+----===============HI-20131203==----
+`
+	text := c.ToMIMEText()
+	if text != expected {
+		t.Errorf("unexpected text.\nGot:\n%s\nExpected:\n%s", text, expected)
+	}
+}
+
+func TestSimpleText(t *testing.T) {
+	c := New()
+	cType := "test/some-type"
+	cVal := "This is some userdata"
+	c.AddPart(cType, cVal)
+
+	expected := `From nobody Tue Dec  3 19:00:57 2013
+Content-Type: multipart/mixed; boundary="--===============HI-20131203==--"
+MIME-Version: 1.0
+
+----===============HI-20131203==--
+Content-Type: test/some-type; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+This is some userdata
+----===============HI-20131203==----
+`
+
+	if s := c.ToMIMEText(); s != expected {
+		t.Errorf("unexpected text.\nGot:\n%s\nExpected:\n%s", s, expected)
+	}
+}


### PR DESCRIPTION
Add simple unit tests to catch the most basic errors. As most of the
operations include talking to AWS, some separate integration tests
would be needed for full test coverage.