### PR TITLE
Better cleanup on wrap

### DIFF
--- a/pkg/mv/mv.go
+++ b/pkg/mv/mv.go
@@ -12,52 +12,84 @@ var (
 	ErrInterrupted = errors.New("the command was interrupted")
 )
 
-// MaybeString encapsulates a string and an eventual error
+// MaybeString encapsulates a string and an eventual error. For use with
+// result channels
 type MaybeString struct {
 	Result string
 	Error  error
 }
-
-var queuedCleanups []cleanupFunc
 
 type cleanupFunc struct {
 	f          func()
 	onlyOnFail bool
 }
 
+var stackedCleanups *cleanupStack
+
+// QueueCleanup will queue a cleanup function to be ran. If onlyOnFail is set,
+// the function will only be ran if Cleanup is ran with failed = true. The
+// functions are put in a stack, so the latest function put in will be ran first
+func QueueCleanup(f func(), onlyOnFail bool) {
+	if stackedCleanups == nil {
+		stackedCleanups = &cleanupStack{
+			mutex: sync.Mutex{},
+			funcs: make([]cleanupFunc, 0),
+		}
+	}
+	stackedCleanups.Push(cleanupFunc{
+		f:          f,
+		onlyOnFail: onlyOnFail,
+	})
+}
+
 // Cleanup will run all queued cleanup functions
 func Cleanup(success bool) {
 	cleaned := false
-	var wg sync.WaitGroup
-	for i := range queuedCleanups {
-		wg.Add(1)
-		go func(index int) {
-			if !success {
-				logging.Debug("Running cleanup function")
-				cleaned = true
-				queuedCleanups[index].f()
-			} else if success && !queuedCleanups[index].onlyOnFail {
-				logging.Debug("Running cleanup function")
-				cleaned = true
-				queuedCleanups[index].f()
-			}
-			wg.Done()
-		}(i)
+	for stackedCleanups.Len() != 0 {
+		f, err := stackedCleanups.Pop()
+		if err != nil {
+			// Stack is empty, shouldn't happen with the check in the loop
+			break
+		}
+		if !success || (success && !f.onlyOnFail) {
+			logging.Debug("Running cleanup function")
+			cleaned = true
+			f.f()
+		}
 	}
-	wg.Wait()
 	if cleaned {
 		logging.Info("Cleanup completed")
 	}
 }
 
-// QueueCleanup will queue a cleanup function to be ran. If onlyOnFail is set,
-// the function will only be ran if Cleanup is ran with failed = true
-func QueueCleanup(f func(), onlyOnFail bool) {
-	if queuedCleanups == nil {
-		queuedCleanups = []cleanupFunc{}
+// A simple thread safe stack to store the cleanup functions
+type cleanupStack struct {
+	mutex sync.Mutex
+	funcs []cleanupFunc
+	size  int
+}
+
+func (s *cleanupStack) Push(f cleanupFunc) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.funcs = append(s.funcs, f)
+	s.size++
+}
+
+func (s *cleanupStack) Pop() (cleanupFunc, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.size == 0 {
+		return cleanupFunc{}, errors.New("the stack is empty")
 	}
-	queuedCleanups = append(queuedCleanups, cleanupFunc{
-		f:          f,
-		onlyOnFail: onlyOnFail,
-	})
+	f := s.funcs[s.size-1]
+	s.funcs = s.funcs[:s.size-1]
+	s.size--
+	return f, nil
+}
+
+func (s *cleanupStack) Len() int {
+	return s.size
 }

--- a/pkg/mv/mv_test.go
+++ b/pkg/mv/mv_test.go
@@ -7,12 +7,13 @@ func TestCleanup(t *testing.T) {
 	f := func() {
 		didRun = true
 	}
-	queuedCleanups = nil
+	stackedCleanups = nil
 	QueueCleanup(f, true)
 	Cleanup(true)
 	if didRun {
 		t.Error("Cleanup should only have run if failure happened")
 	}
+	QueueCleanup(f, true)
 	Cleanup(false)
 	if !didRun {
 		t.Error("Cleanup never happened")


### PR DESCRIPTION
The main new thing in this pull request is that if executions somehow fails during the wrapping of an instance, the CLI will attempt to restore the instance by moving back the guest volume as the root device. To do this, I also had to change the way cleanup functions are executed.

Cleanup functions are now put on a stack, so that every cleanup function that run essentially back up one step. This makes sure that e.g. when wrapping an image, the instance is first restored before trying to terminate it. With the previous behavior, a race condition would occur and one of the cleanups would fail because of invalid state.