### PR TITLE
Add flag to specify subnet ID

### DIFF
--- a/cmd/metavisor.go
+++ b/cmd/metavisor.go
@@ -57,6 +57,7 @@ var (
 	awsWrapAMIVersion = awsWrapAMI.Flag("metavisor-version", "Which version of the MV to use").PlaceHolder("VERSION").String()
 	awsWrapAMIAMI     = awsWrapAMI.Flag("metavisor-image", "AMI ID of MV to use, must be in correct region").Hidden().PlaceHolder("AMI-ID").String()
 	awsWrapAMIDomain  = awsWrapAMI.Flag("service-domain", "Specify which Yeti to talk to").Hidden().PlaceHolder("DOMAIN").Envar(envServiceDomain).String()
+	awsWrapAMISubnet  = awsWrapAMI.Flag("subnet-id", "Use specified subnet rather than default when launching temporary instance").PlaceHolder("ID").String()
 	awsWrapAMIID      = awsWrapAMI.Arg("ID", "ID of the instance to wrap").Required().String()
 
 	// AWS Share logs
@@ -68,6 +69,7 @@ var (
 	awsShareLogsBastionHost = awsShareLogs.Flag("bastion-host", "Host of bastion to tunnel through").PlaceHolder("HOST").Hidden().String() // TODO: Support bastion
 	awsShareLogsBastionUser = awsShareLogs.Flag("bastion-user", "Bastion username to tunnel through").PlaceHolder("NAME").Hidden().String()
 	awsShareLogsBastionKey  = awsShareLogs.Flag("bastion-key-path", "Key in bastion to use when tunneling").PlaceHolder("PATH").Hidden().String()
+	awsShareLogsSubnet      = awsShareLogs.Flag("subnet-id", "Use specified subnet rather than default when launching temporary instance").PlaceHolder("ID").String()
 	awsShareLogsID          = awsShareLogs.Arg("ID", "ID of instance or snapshot to get logs from").Required().String()
 
 	// Generic commands
@@ -210,6 +212,7 @@ func wrapAMI(ctx context.Context) {
 		MetavisorVersion: *awsWrapAMIVersion,
 		MetavisorAMI:     *awsWrapAMIAMI,
 		ServiceDomain:    *awsWrapAMIDomain,
+		SubnetID:         *awsWrapAMISubnet,
 		IAMRoleARN:       *awsCommandIAM,
 		IAMDeviceARN:     *awsCommandIAMMFA,
 		IAMCode:          *awsCommandIAMCode,
@@ -232,6 +235,7 @@ func shareLogs(ctx context.Context) {
 		BastionHost:           *awsShareLogsBastionHost,
 		BastionUsername:       *awsShareLogsBastionUser,
 		BastionPrivateKeyPath: *awsShareLogsBastionKey,
+		SubnetID:              *awsShareLogsSubnet,
 		IAMRoleARN:            *awsCommandIAM,
 		IAMDeviceARN:          *awsCommandIAMMFA,
 		IAMCode:               *awsCommandIAMCode,

--- a/pkg/csp/aws/aws.go
+++ b/pkg/csp/aws/aws.go
@@ -18,12 +18,14 @@ import (
 )
 
 const (
-	accessDeniedErrorCode = "AccessDenied"
-	keyNotFoundErrorCode  = "InvalidKeyPair.NotFound"
-	instanceIDErrorCode   = "InvalidInstanceID"
-	amiIDErrorCode        = "InvalidAMIID"
-	volumeNotFound        = "InvalidVolumeID"
-	snapshotNotFound      = "InvalidSnapshot.NotFound"
+	accessDeniedErrorCode   = "AccessDenied"
+	keyNotFoundErrorCode    = "InvalidKeyPair.NotFound"
+	instanceIDErrorCode     = "InvalidInstanceID"
+	amiIDErrorCode          = "InvalidAMIID"
+	volumeNotFound          = "InvalidVolumeID"
+	snapshotNotFound        = "InvalidSnapshot.NotFound"
+	vpcNotFoundErrorCode    = "VPCResourceNotSpecified"
+	subnetNotFoundErrorCode = "InvalidSubnetID.NotFound"
 
 	genericVolumeType = "gp2"
 
@@ -68,6 +70,10 @@ var (
 	ErrInstanceImpaired = errors.New("instance is in impaired state")
 	// ErrInvalidARN is returned if a specified ARN can't be assumed
 	ErrInvalidARN = errors.New("failed to assume role with given ARN")
+	// ErrRequiresSubnet is returned when a subnet must be explicitly specified in order to launch an instance
+	ErrRequiresSubnet = errors.New("a subnet ID must be specified to launch instance")
+	// ErrInvalidSubnetID is returned if a specified subnet ID does not work
+	ErrInvalidSubnetID = errors.New("the specified subnet is not valid")
 )
 
 var validVolumeTypes = []string{"gp2", "io1", "st1", "sc1", "standard"}
@@ -93,7 +99,7 @@ type Service interface {
 	// GetInstance returns an instance representation of the instance with the given ID
 	GetInstance(ctx context.Context, instanceID string) (Instance, error)
 	// LaunchInstance will use a new instance with the specified attributes
-	LaunchInstance(ctx context.Context, image, instanceType, userData, keyName string, extraDevices ...NewDevice) (Instance, error)
+	LaunchInstance(ctx context.Context, image, instanceType, userData, keyName, subnetID string, extraDevices ...NewDevice) (Instance, error)
 	// TerminateInstance will terminate the instance with the given ID
 	TerminateInstance(ctx context.Context, instanceID string) error
 	// StopInstance will stop the instance with the given ID

--- a/pkg/csp/aws/helper.go
+++ b/pkg/csp/aws/helper.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	idPrefix   = "i-"
-	snapPrefix = "snap-"
-	amiPrefix  = "ami-"
+	idPrefix     = "i-"
+	snapPrefix   = "snap-"
+	amiPrefix    = "ami-"
+	subnetPrefix = "subnet-"
 )
 
 // Amazon Linux AMIs (HVM EBS) collected on Feb 14 2018, from:
@@ -60,6 +61,11 @@ func IsSnapshotID(id string) bool {
 func IsAMIID(id string) bool {
 	// TODO: Maybe use regex?
 	return strings.HasPrefix(id, amiPrefix)
+}
+
+func IsSubnetID(id string) bool {
+	// TODO: Maybe use regex?
+	return strings.HasPrefix(id, subnetPrefix)
 }
 
 // IsValidRegion will validate a specified region to make sure it exist in AWS

--- a/pkg/mv/wrap/instance.go
+++ b/pkg/mv/wrap/instance.go
@@ -141,6 +141,11 @@ func awsVerifyConfig(conf Config) error {
 		logging.Error("The specified Metavisor AMI is not a valid AMI ID")
 		return ErrInvalidAMI
 	}
+	if conf.SubnetID != "" && !aws.IsSubnetID(conf.SubnetID) {
+		// User specified an invalid subnet ID
+		logging.Error("The specified Subnet ID is not a valid subnet ID")
+		return aws.ErrInvalidID
+	}
 	if conf.Token != "" {
 		isValid := isValidToken(conf.Token)
 		if !isValid {

--- a/pkg/mv/wrap/wrap.go
+++ b/pkg/mv/wrap/wrap.go
@@ -19,6 +19,7 @@ type Config struct {
 	IAMRoleARN       string
 	IAMDeviceARN     string
 	IAMCode          string
+	SubnetID         string
 }
 
 const (


### PR DESCRIPTION
Add an optional flag to the wrap-ami and share-logs command to
specify a subnet ID. This will be used when launching temporary
instances. It's required for any user who does not have a default
VPC in their AWS account.