### PR TITLE
Improve error handling

### DIFF
--- a/pkg/mv/mv.go
+++ b/pkg/mv/mv.go
@@ -44,6 +44,9 @@ func QueueCleanup(f func(), onlyOnFail bool) {
 
 // Cleanup will run all queued cleanup functions
 func Cleanup(success bool) {
+	if stackedCleanups == nil {
+		return
+	}
 	cleaned := false
 	for stackedCleanups.Len() != 0 {
 		f, err := stackedCleanups.Pop()


### PR DESCRIPTION
- Fix bug where cleanup would panic if there was no cleanup functions
on the Stack.

- Returns an error if specifying an AWS key name that doesn't exist

- Returns an error if specifying a key file that doesn't exist