### PR TITLE
Add support for upcomming amis.json structure

### DIFF
--- a/pkg/mv/aws.go
+++ b/pkg/mv/aws.go
@@ -120,6 +120,43 @@ func determineLatest(ctx context.Context, client *s3.S3, allVersions []string) (
 	return "", errors.New("No latest version")
 }
 
+// This below is a temporary hack to make sure we support both the old and
+// the new coming structure of the amis.json file in the S3 bucket. The
+// custom unmarshal function makes sure to use the new format if it's there,
+// otherwise fall back to use old format
+type amisImage struct {
+	Region string `json:"region"`
+	ID     string `json:"id"`
+}
+
+type mvAMIMap map[string]string
+
+func (m *mvAMIMap) UnmarshalJSON(b []byte) error {
+	str := string(b)
+	if strings.Contains(str, "images") {
+		tmp := struct {
+			Images []amisImage `json:"images"`
+		}{}
+		err := json.Unmarshal(b, &tmp)
+		if err != nil {
+			return err
+		}
+		res := make(map[string]string)
+		for _, img := range tmp.Images {
+			res[img.Region] = img.ID
+		}
+		*m = res
+	} else {
+		tmp := make(map[string]string)
+		err := json.Unmarshal(b, &tmp)
+		if err != nil {
+			return err
+		}
+		*m = tmp
+	}
+	return nil
+}
+
 func getObjectBody(ctx context.Context, client *s3.S3, key string) (map[string]string, error) {
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(prodBucketName),
@@ -130,7 +167,7 @@ func getObjectBody(ctx context.Context, client *s3.S3, key string) (map[string]s
 		return nil, err
 	}
 	decoder := json.NewDecoder(amis.Body)
-	amisMap := make(map[string]string)
+	amisMap := mvAMIMap{}
 	err = decoder.Decode(&amisMap)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This makes sure that when the structure of the amis.json file is updated (as it's planned to), the CLI will keep working. If the CLI detects the new format, it will use that to parse, otherwise it will fall back to the old format.