### PR TITLE
Make release binary names consistent with uname

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ deploy:
   tag_name: $TRAVIS_TAG
   target_commitish: $TRAVIS_COMMIT
   file:
-    - metavisor-linux
-    - metavisor-darwin
-    - metavisor-windows.exe
+    - metavisor-Linux
+    - metavisor-Darwin
+    - metavisor-Windows.exe
   skip_cleanup: true
   on:
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 GOOS_LINUX        := linux
 GOOS_WINDOWS      := windows
 GOOS_DARWIN       := darwin
-OUT_LINUX         := metavisor-linux
-OUT_DARWIN        := metavisor-darwin
-OUT_WINDOWS       := metavisor-windows.exe
+OUT_LINUX         := metavisor-Linux
+OUT_DARWIN        := metavisor-Darwin
+OUT_WINDOWS       := metavisor-Windows.exe
 ARCH              := amd64
 
 ifeq ($(OS),Windows_NT)

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ This make target can be used to create a binary for the specified platform, rega
 ### `make docker-build-all`
 Create binaries for Windows, Linux, and Darwin. The binaries will have a suffix indicating which platform they're built for. I.e. `make docker-build-all` outputs:
 
-- metavisor-linux
-- metavisor-darwin
-- metavisor-windows.exe
+- metavisor-Linux
+- metavisor-Darwin
+- metavisor-Windows.exe
 
 ## Licensing
 This project is licensed under the Apache 2.0 license. Please see the `LICENSE` file for full licensing details.


### PR DESCRIPTION
Make sure the binary names have capitalised OS-names, so that you can use this little handy line to install:

```
curl -L https://github.com/brkt/metavisor-cli/releases/download/RELEASE_NAME/metavisor-`uname -s` -o /usr/local/bin/metavisor
chmod +x /usr/local/bin/metavisor
```

This should probably be put in release notes too, for easy install. :)
