### PR TITLE
Add easy build support for FreeBSD and OpenBSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -415,6 +415,8 @@ __pycache__/
 metavisor
 metavisor-linux
 metavisor-darwin
+metavisor-freebsd
+metavisor-openbsd
 metavisor-windows.exe
 metavisor.exe
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ deploy:
   file:
     - metavisor-linux
     - metavisor-darwin
+    - metavisor-freebsd
+    - metavisor-openbsd
     - metavisor-windows.exe
   skip_cleanup: true
   on:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 GOOS_LINUX        := linux
 GOOS_WINDOWS      := windows
+GOOS_FREEBSD      := freebsd
+GOOS_OPENBSD      := openbsd
 GOOS_DARWIN       := darwin
 OUT_LINUX         := metavisor-linux
 OUT_DARWIN        := metavisor-darwin
+OUT_FREEBSD       := metavisor-freebsd
+OUT_OPENBSD       := metavisor-openbsd
 OUT_WINDOWS       := metavisor-windows.exe
 ARCH              := amd64
 
@@ -12,6 +16,10 @@ else
 	HOST_OS := $(shell uname)
 	ifeq ($(HOST_OS), Darwin)
 		GO_OS := $(GOOS_DARWIN)
+	else ifeq ($(HOST_OS), FreeBSD)
+		GO_OS := $(GOOS_FREEBSD)
+	else ifeq ($(HOST_OS), OpenBSD)
+		GO_OS := $(GOOS_OPENBSD)
 	else
 		GO_OS := $(GOOS_LINUX)
 	endif
@@ -20,6 +28,8 @@ endif
 %-linux : override GO_OS = $(GOOS_LINUX)
 %-darwin : override GO_OS = $(GOOS_DARWIN)
 %-windows : override GO_OS = $(GOOS_WINDOWS)
+%-freebsd : override GO_OS = $(GOOS_FREEBSD)
+%-openbsd : override GO_OS = $(GOOS_OPENBSD)
 
 all: build
 
@@ -39,10 +49,16 @@ build-all:
 	mv metavisor.exe $(OUT_WINDOWS)
 	@$(MAKE) build-darwin
 	mv metavisor $(OUT_DARWIN)
+	@$(MAKE) build-freebsd
+	mv metavisor $(OUT_FREEBSD)
+	@$(MAKE) build-openbsd
+	mv metavisor $(OUT_OPENBSD)
 
 build-linux: build
 build-darwin: build
 build-windows: build
+build-freebsd: build
+build-openbsd: build
 
 docker-build-img:
 	docker build --build-arg GOOS=$(GO_OS) -t metavisor-cli .
@@ -60,8 +76,14 @@ docker-build-all:
 	mv metavisor.exe $(OUT_WINDOWS)
 	@$(MAKE) docker-build-darwin
 	mv metavisor $(OUT_DARWIN)
+	@$(MAKE) docker-build-freebsd
+	mv metavisor $(OUT_FREEBSD)
+	@$(MAKE) docker-build-openbsd
+	mv metavisor $(OUT_OPENBSD)
 
 docker-build-linux: docker-build-img docker-build
 docker-build-darwin: docker-build-img docker-build
+docker-build-freebsd: docker-build-img docker-build
+docker-build-openbsd: docker-build-img docker-build
 docker-build-windows: docker-build-img docker-build
 	mv metavisor metavisor.exe

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ The `metavisor-cli` is a command-line interface to easily deploy cloud instances
 The latest release of **metavisor-cli** is [1.0.0](https://github.com/brkt/metavisor-cli/releases/latest).
 
 ## Requirements
-This CLI is implemented using [Go](https://golang.org) (version 1.10 to be specific). Go must be installed in order to compile the CLI. If you don't have Go installed, every release of the CLI is also accompanied by pre-compiled binaries for Darwin, Linux, and Windows which don't have any additional dependenices. To get the correct dependency versions when compiling, make sure to use the depedency management tool `dep`.
+This CLI is implemented using [Go](https://golang.org) (version 1.10 to be specific). Go must be installed in order to compile the CLI. If you don't have Go installed, every release of the CLI is also accompanied by pre-compiled binaries for Darwin, Linux, FreeBSD, OpenBSD, and Windows which don't have any additional dependenices. To get the correct dependency versions when compiling, make sure to use the depedency management tool `dep`.
 
 ## Installation
-Start by either compiling the CLI from the source code, or grab a pre-compiled binary from the latest release of the CLI. To compile the CLI yourself, first make sure your Go environment is properly setup, then run:
+Start by either compiling the CLI from the source code, or grab a pre-compiled binary from the latest release of the CLI. To compile the CLI yourself, first make sure your Go environment is properly setup and that you cloned this project to `$GOPATH/src/github.com/brkt/metavisor-cli`, then run:
 ```
 $ dep ensure
 $ go build cmd/metavisor.go
@@ -39,14 +39,16 @@ If Go or `dep` is not installed, and you still want to compile from the source c
 ### `make docker-build`
 Will compile a binary for your current system, e.g. if you're running Windows a binary called `metavisor.exe` will be created.
 
-### `make docker-build-[darwin/linux/windows]`
+### `make docker-build-[darwin/linux/openbsd/freebsd/windows]`
 This make target can be used to create a binary for the specified platform, regarless of which system you're currently using. E.g. running `make docker-build-darwin` on a Windows machine will create a binary called `metavisor`.
 
 ### `make docker-build-all`
-Create binaries for Windows, Linux, and Darwin. The binaries will have a suffix indicating which platform they're built for. I.e. `make docker-build-all` outputs:
+Create binaries for Windows, Linux, OpenBSD, FreeBSD, and Darwin. The binaries will have a suffix indicating which platform they're built for. I.e. `make docker-build-all` outputs:
 
 - metavisor-linux
 - metavisor-darwin
+- metavisor-openbsd
+- metavisor-freebsd
 - metavisor-windows.exe
 
 ## Licensing


### PR DESCRIPTION
Add make targets to make sure that it's easy to build the CLI for
both OpenBSD and FreeBSD. Any new release will also include binaries
for these platforms.