### PR TITLE
Fix result channel race condition bug

### DIFF
--- a/pkg/mv/wrap/wrap.go
+++ b/pkg/mv/wrap/wrap.go
@@ -123,11 +123,12 @@ func Image(ctx context.Context, region, id string, conf Config) (string, error) 
 				Result: "",
 				Error:  err,
 			}
-		}
-		img, err := awsWrapImage(ctx, service, region, id, conf)
-		res <- mv.MaybeString{
-			Result: img,
-			Error:  err,
+		} else {
+			img, err := awsWrapImage(ctx, service, region, id, conf)
+			res <- mv.MaybeString{
+				Result: img,
+				Error:  err,
+			}
 		}
 	}()
 


### PR DESCRIPTION
Fixes a bug where if initializing a new service fails, there is
a potential risk for a panic to happen as the goroutine still
continues execution after writing the error to the result channel.

This meant that even though an error is written to the result
channel, the subsequent function call still tries to use the nil
service before the result channel has been handled in the select
statement.