### PR TITLE
Better error messages for invalid IDs

### DIFF
--- a/pkg/csp/aws/helper.go
+++ b/pkg/csp/aws/helper.go
@@ -41,8 +41,20 @@ var genericAMIMap = map[string]string{
 }
 
 var (
-	// ErrInvalidID is returned if a specified ID is not of correct format
-	ErrInvalidID = errors.New("the specified ID is not of valid format")
+	// ErrInvalidID is returned if a specified ID is not in the correct format
+	ErrInvalidID = errors.New("the specified ID is not formatted properly")
+
+	// ErrInvalidInstanceID is returned if a specified instance ID is not in the correct format
+	ErrInvalidInstanceID = errors.New("the specified instance ID is not formatted properly - expected i-XXXXXXXXXXX")
+
+	// ErrInvalidAMIID is returned if a specified AMI ID is not in the correct format
+	ErrInvalidAMIID = errors.New("the specified AMI ID is not formatted properly - expected ami-XXXXXXX")
+
+	// ErrInvalidSnapshotID is returned if a specified snapshot ID is not in the correct format
+	ErrInvalidSnapshotID = errors.New("the specified snapshot ID is not formatted properly - expected snap-XXXXXXX")
+
+	// ErrInvalidVolumeID is returned if a specified volume ID is not in the correct format
+	ErrInvalidVolumeID = errors.New("the specified volume ID is not formatted properly - expected vol-XXXXXXX")
 )
 
 // IsInstanceID determines if the specified ID belong to an instance or not

--- a/pkg/csp/aws/instance.go
+++ b/pkg/csp/aws/instance.go
@@ -93,7 +93,7 @@ func (a *awsService) GetInstance(ctx context.Context, instanceID string) (Instan
 
 func (a *awsService) LaunchInstance(ctx context.Context, imageID, instanceType, userData, keyName, subnetID string, extraDevices ...NewDevice) (Instance, error) {
 	if !IsAMIID(imageID) {
-		return nil, ErrInvalidID
+		return nil, ErrInvalidAMIID
 	}
 	if strings.TrimSpace(keyName) != "" {
 		if keyExist, err := a.KeyPairExist(ctx, keyName); (err != nil && err != ErrNotAllowed) || (!keyExist && err == nil) {
@@ -255,7 +255,7 @@ func (a *awsService) TerminateInstance(ctx context.Context, instanceID string) e
 
 func (a *awsService) ModifyInstanceAttribute(ctx context.Context, instanceID string, attr instanceAttribute, value interface{}) error {
 	if strings.TrimSpace(instanceID) == "" {
-		return ErrInvalidID
+		return ErrInvalidInstanceID
 	}
 	input := &ec2.ModifyInstanceAttributeInput{
 		InstanceId: aws.String(instanceID),

--- a/pkg/csp/aws/snapshot.go
+++ b/pkg/csp/aws/snapshot.go
@@ -90,7 +90,7 @@ func (a *awsService) CreateSnapshot(ctx context.Context, name, sourceVolumeID st
 
 func (a *awsService) DeleteSnapshot(ctx context.Context, snapshotID string) error {
 	if strings.TrimSpace(snapshotID) == "" {
-		return ErrInvalidID
+		return ErrInvalidSnapshotID
 	}
 	input := &ec2.DeleteSnapshotInput{
 		SnapshotId: aws.String(snapshotID),

--- a/pkg/csp/aws/volume.go
+++ b/pkg/csp/aws/volume.go
@@ -16,7 +16,7 @@ type volume struct {
 
 func (a *awsService) CreateVolume(ctx context.Context, sourceSnapshotID, volumeType, zone string, size int64) (Volume, error) {
 	if strings.TrimSpace(sourceSnapshotID) == "" {
-		return nil, ErrInvalidID
+		return nil, ErrInvalidSnapshotID
 	}
 	var validVolume bool
 	for i := range validVolumeTypes {
@@ -54,7 +54,7 @@ func (a *awsService) CreateVolume(ctx context.Context, sourceSnapshotID, volumeT
 
 func (a *awsService) DeleteVolume(ctx context.Context, volumeID string) error {
 	if strings.TrimSpace(volumeID) == "" {
-		return ErrInvalidID
+		return ErrInvalidVolumeID
 	}
 	input := &ec2.DeleteVolumeInput{
 		VolumeId: aws.String(volumeID),
@@ -74,9 +74,14 @@ func (a *awsService) DeleteVolume(ctx context.Context, volumeID string) error {
 }
 
 func (a *awsService) DetachVolume(ctx context.Context, volumeID, instanceID, deviceName string) error {
-	if strings.TrimSpace(volumeID) == "" || strings.TrimSpace(instanceID) == "" {
-		return ErrInvalidID
+	if strings.TrimSpace(volumeID) == "" {
+		return ErrInvalidVolumeID
 	}
+
+	if strings.TrimSpace(instanceID) == "" {
+		return ErrInvalidInstanceID
+	}
+
 	input := &ec2.DetachVolumeInput{
 		Device:     aws.String(deviceName),
 		InstanceId: aws.String(instanceID),
@@ -95,9 +100,14 @@ func (a *awsService) DetachVolume(ctx context.Context, volumeID, instanceID, dev
 }
 
 func (a *awsService) AttachVolume(ctx context.Context, volumeID, instanceID, deviceName string) error {
-	if strings.TrimSpace(volumeID) == "" || strings.TrimSpace(instanceID) == "" {
-		return ErrInvalidID
+	if strings.TrimSpace(volumeID) == "" {
+		return ErrInvalidVolumeID
 	}
+
+	if strings.TrimSpace(instanceID) == "" {
+		return ErrInvalidInstanceID
+	}
+
 	input := &ec2.AttachVolumeInput{
 		Device:     aws.String(deviceName),
 		InstanceId: aws.String(instanceID),
@@ -117,7 +127,7 @@ func (a *awsService) AttachVolume(ctx context.Context, volumeID, instanceID, dev
 
 func (a *awsService) AwaitVolumeAvailable(ctx context.Context, volumeID string) error {
 	if strings.TrimSpace(volumeID) == "" {
-		return ErrInvalidID
+		return ErrInvalidVolumeID
 	}
 	input := &ec2.DescribeVolumesInput{
 		VolumeIds: aws.StringSlice([]string{volumeID}),
@@ -135,7 +145,7 @@ func (a *awsService) AwaitVolumeAvailable(ctx context.Context, volumeID string) 
 
 func (a *awsService) AwaitVolumeInUse(ctx context.Context, volumeID string) error {
 	if strings.TrimSpace(volumeID) == "" {
-		return ErrInvalidID
+		return ErrInvalidVolumeID
 	}
 	input := &ec2.DescribeVolumesInput{
 		VolumeIds: aws.StringSlice([]string{volumeID}),

--- a/pkg/mv/share/aws.go
+++ b/pkg/mv/share/aws.go
@@ -63,7 +63,7 @@ func awsSnapFromID(ctx context.Context, id string, awsSvc aws.Service) (aws.Snap
 		logging.Debugf("The ID '%s' is a snapshot", id)
 		s, err := awsSvc.GetSnapshot(ctx, id)
 		if err != nil {
-			// THe specified instance doesn't exist or insufficient
+			// The specified instance doesn't exist or insufficient
 			// permissions
 			return nil, err
 		}

--- a/pkg/mv/share/share.go
+++ b/pkg/mv/share/share.go
@@ -88,7 +88,7 @@ func awsShareLogs(ctx context.Context, region, id string, conf Config) (string, 
 	if conf.SubnetID != "" && !aws.IsSubnetID(conf.SubnetID) {
 		// User specified an invalid subnet ID
 		logging.Error("The specified Subnet ID is not a valid subnet ID")
-		return "", aws.ErrInvalidID
+		return "", aws.ErrInvalidSubnetID
 	}
 	path, err := parseOutPath(conf.LogsPath)
 	if err != nil {

--- a/pkg/mv/wrap/image.go
+++ b/pkg/mv/wrap/image.go
@@ -19,12 +19,12 @@ const (
 
 func awsWrapImage(ctx context.Context, awsSvc aws.Service, region, id string, conf Config) (string, error) {
 	if !aws.IsAMIID(id) {
-		return "", aws.ErrInvalidID
+		return "", aws.ErrInvalidAMIID
 	}
 	if conf.SubnetID != "" && !aws.IsSubnetID(conf.SubnetID) {
 		// User specified an invalid subnet ID
 		logging.Error("The specified Subnet ID is not a valid subnet ID")
-		return "", aws.ErrInvalidID
+		return "", aws.ErrInvalidSubnetID
 	}
 	if conf.Token != "" {
 		isValid := isValidToken(conf.Token)

--- a/pkg/mv/wrap/instance.go
+++ b/pkg/mv/wrap/instance.go
@@ -12,7 +12,7 @@ import (
 
 func awsWrapInstance(ctx context.Context, awsSvc aws.Service, region, id string, conf Config) (string, error) {
 	if !aws.IsInstanceID(id) {
-		return "", aws.ErrInvalidID
+		return "", aws.ErrInvalidInstanceID
 	}
 	err := awsVerifyConfig(conf)
 	if err != nil {
@@ -144,7 +144,7 @@ func awsVerifyConfig(conf Config) error {
 	if conf.SubnetID != "" && !aws.IsSubnetID(conf.SubnetID) {
 		// User specified an invalid subnet ID
 		logging.Error("The specified Subnet ID is not a valid subnet ID")
-		return aws.ErrInvalidID
+		return aws.ErrInvalidSubnetID
 	}
 	if conf.Token != "" {
 		isValid := isValidToken(conf.Token)


### PR DESCRIPTION
Create custom error messages instead of using ErrInvalidID for
everything. Each error message contains a small explanation as to
what is being requested, instead of just "invalid format" - for
example.