### PR TITLE
Improve tagging on temporary resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ If you instead decide to grab a binary from the releases page, make sure to get 
 
 After you have a compiled binary of the CLI, simply put it somewhere in your `$PATH` and you're ready to start using it. Try it out by running `metavisor version`.
 
+## Usage
+Assuming you have the CLI installed and available in your `$PATH` as `metavisor`, you can find all available commands as well as their corresponding parameters by running:
+```
+$ metavisor help
+```
+In order to find more specific help for a command, e.g. for wrapping instances, run:
+```
+$ metavisor aws wrap-instance --help
+```
+The easiest way to try the Metavisor out is to wrap one of your existing instances with it. Here follows an example for wrapping an instance with the ID `i-foobar123456` which is running in the region `us-west-2`:
+```
+$ metavisor aws wrap-instance --region=us-west-2 --token=$YOUR_LAUNCH_TOKEN i-foobar123456
+```
+Notice the `--token` argument, where a so-called launch token must be specified (in this case saved in the `$YOUR_LAUNCH_TOKEN` environment variable). The launch token is required in order to allow the Metavisor to communicate with the [Metavisor Director Console](https://mgmt.brkt.com). You can get a launch token by logging into your account in the [Metavisor Director Console](https://mgmt.brkt.com) and navigating to the `Generate Userdata` section of the `Settings` tab, and then clicking: `Generate --> OK --> COPY TOKEN ONLY`.
+
+### AWS Permissions
+The CLI requires a set of IAM permissions in EC2 in order to work properly. This is required to get the Metavisor up and running in your AWS account. An example policy template with the minimum permission requirements can be found in the `policy_template.json` file. If you attach this policy to an IAM role, that role can then be used by specifing the `--iam` flag in the CLI. Here is an example of wrapping an instance with the role `mv-cli-role` (assuming your AWS account ID is `123456789012`):
+```
+$ export YOUR_LAUNCH_TOKEN=<your launch token from Metavisor Director Console>
+$ export ROLE=arn:aws:iam::123456789012:role/mv-cli-role
+$ metavisor aws wrap-instance --region=us-west-2 --token=$YOUR_LAUNCH_TOKEN --iam=$ROLE i-foobar123456
+```
+
 ## Contributing
 The metavisor-cli project uses `dep` to manage dependencies. For more information about `dep`, please take a look at [golang.github.io/dep/](https://golang.github.io/dep/).
 

--- a/pkg/csp/aws/aws.go
+++ b/pkg/csp/aws/aws.go
@@ -37,6 +37,10 @@ const (
 	// SriovNetIsSupported is the value of SriovNetSupport when it's actually
 	// supported on the instance.
 	SriovNetIsSupported = "simple"
+
+	// A tag is added to all resources created by the CLI
+	cliResourceTagKey   = "metavisor-cli"
+	cliResourceTagValue = "true"
 )
 
 var (
@@ -99,7 +103,7 @@ type Service interface {
 	// GetInstance returns an instance representation of the instance with the given ID
 	GetInstance(ctx context.Context, instanceID string) (Instance, error)
 	// LaunchInstance will use a new instance with the specified attributes
-	LaunchInstance(ctx context.Context, image, instanceType, userData, keyName, subnetID string, extraDevices ...NewDevice) (Instance, error)
+	LaunchInstance(ctx context.Context, image, instanceType, userData, keyName, subnetID string, tags map[string]string, extraDevices ...NewDevice) (Instance, error)
 	// TerminateInstance will terminate the instance with the given ID
 	TerminateInstance(ctx context.Context, instanceID string) error
 	// StopInstance will stop the instance with the given ID

--- a/pkg/csp/aws/snapshot.go
+++ b/pkg/csp/aws/snapshot.go
@@ -79,7 +79,10 @@ func (a *awsService) CreateSnapshot(ctx context.Context, name, sourceVolumeID st
 		logging.Error("Snapshot never became ready")
 		return nil, err
 	}
-	nameTags := map[string]string{"Name": name}
+	nameTags := map[string]string{
+		"Name":            name,
+		cliResourceTagKey: cliResourceTagValue,
+	}
 	err = a.TagResources(ctx, nameTags, res.ID())
 	if err == ErrNotAllowed {
 		logging.Warning("Insufficient IAM permissions to tag resource, skipping Name")

--- a/policy_template.json
+++ b/policy_template.json
@@ -1,0 +1,48 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AttachVolume",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceAttribute",
+                "ec2:CreateKeyPair",
+                "ec2:CreateImage",
+                "ec2:DescribeSnapshots",
+                "ec2:DescribeVolumeStatus",
+                "ec2:StartInstances",
+                "ec2:DescribeVolumes",
+                "ec2:CreateSnapshot",
+                "ec2:ModifyInstanceAttribute",
+                "ec2:DescribeKeyPairs",
+                "ec2:DescribeInstanceStatus",
+                "ec2:DetachVolume",
+                "ec2:DescribeSnapshotAttribute",
+                "ec2:DescribeTags",
+                "ec2:CreateTags",
+                "ec2:RunInstances",
+                "ec2:StopInstances",
+                "ec2:DescribeVolumeAttribute",
+                "ec2:CreateVolume",
+                "ec2:DescribeImages",
+                "ec2:DeleteKeyPair"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DeleteSnapshot",
+                "ec2:DeleteVolume",
+                "ec2:TerminateInstances"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:ResourceTag/metavisor-cli": "true"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Make sure that all temporary resources created by the CLI are
properly tagged so that they can be identified and controlled
through IAM policy conditions.

Instances, volumes and snapshots created by the CLI will have
the tag "metavisor-cli: true" on them.

This also adds a template IAM policy with all the minimum
requirements for the CLI to work properly. See the
policy_template.json file for this.